### PR TITLE
Fix ESLint warning enforcing content in heading elements

### DIFF
--- a/packages/gatsby-theme-blog-core/src/components/post-title.js
+++ b/packages/gatsby-theme-blog-core/src/components/post-title.js
@@ -1,5 +1,9 @@
 import React from "react"
 
-const PostTitle = (props) => <h1 {...props} className="post-title" />
+const PostTitle = (props) => (
+  <h1 className="post-title" {...props}>
+    {props.children}
+  </h1>
+)
 
 export default PostTitle


### PR DESCRIPTION
This fixes the warning message:
"Headings must have content and the content must be accessible
by a screen reader jsx-a11y/heading-has-content"