### PR TITLE
Add link to `gatsby-theme-blog-core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Gatsby Themes
 
 This is a repo for Gatsby's official
-themes. 
+themes.
 
 - `gatsby-theme-blog`
-- `gatsby-theme-blog-core`
+- [gatsby-theme-blog-core](packages/gatsby-theme-blog-core)
 - `gatsby-theme-notes`
 - `gatsby-theme-blog-darkmode`
 - `gatsby-theme-ui-preset`
@@ -41,11 +41,13 @@ yarn start
 This repository is set up with Cypress tests that run automatically in GitHub. If you'd like to run them locally you can do so in develop mode or build mode.
 
 For develop mode:
+
 ```sh
 yarn e2e:dev
 ```
 
 For build mode:
+
 ```sh
 yarn e2e:ci
 ```


### PR DESCRIPTION
Hi, I made a small change to README.md. I added a link to one of the theme packages.