### PR TITLE
add links to README theme starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Gatsby Themes
 
 This is a repo for Gatsby's official
-themes. 
+themes.
 
-- `gatsby-theme-blog`
+- [`gatsby-theme-blog`](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-blog-core)
 - `gatsby-theme-blog-core`
 - `gatsby-theme-notes`
 - `gatsby-theme-blog-darkmode`
@@ -41,11 +41,13 @@ yarn start
 This repository is set up with Cypress tests that run automatically in GitHub. If you'd like to run them locally you can do so in develop mode or build mode.
 
 For develop mode:
+
 ```sh
 yarn e2e:dev
 ```
 
 For build mode:
+
 ```sh
 yarn e2e:ci
 ```


### PR DESCRIPTION
This PR adds links to the list of theme starters, so our contributors can access the various theme starters in a more straightforward manner right from this repo.