### PR TITLE
chore: Add prettier and modify lerna

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Gatsby Themes
 
-This is a repo for Gatsby's official
-themes. 
+This is a repo for Gatsby's official themes.
 
 - `gatsby-theme-blog`
 - `gatsby-theme-blog-core`
@@ -41,11 +40,13 @@ yarn start
 This repository is set up with Cypress tests that run automatically in GitHub. If you'd like to run them locally you can do so in develop mode or build mode.
 
 For develop mode:
+
 ```sh
 yarn e2e:dev
 ```
 
 For build mode:
+
 ```sh
 yarn e2e:ci
 ```

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,14 @@
 {
   "packages": ["packages/*"],
   "version": "independent",
-  "workspaces": true
+  "useWorkspaces": true,
+  "command": {
+    "publish": {
+      "allowBranch": "master",
+      "bump": "patch",
+      "conventionalCommits": true,
+      "message": "chore(release): Publish"
+    }
+  },
+  "loglevel": "success"
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "lerna": "lerna",
+    "lint": "prettier \"**/*.{md,yaml,yml}\" --write",
     "start": "yarn workspace gatsby-starter-theme develop",
     "cy:open": "cypress open",
     "cy:run": "cross-env CYPRESS_baseUrl=http://localhost:9000 cypress run",
@@ -26,6 +27,9 @@
       "eslint --fix"
     ],
     "*.{html,css,less,ejs,json}": [
+      "prettier --write"
+    ],
+    "*.{md,yaml,yml}": [
       "prettier --write"
     ]
   },
@@ -52,6 +56,7 @@
     "gatsby-cypress": "^0.4.4",
     "husky": "^4.2.5",
     "lerna": "^3.22.1",
-    "lint-staged": "^10.2.11"
+    "lint-staged": "^10.2.11",
+    "prettier": "^2.0.5"
   }
 }

--- a/packages/gatsby-theme-blog-core/README.md
+++ b/packages/gatsby-theme-blog-core/README.md
@@ -54,14 +54,14 @@ module.exports = {
 
 ### Theme options
 
-| Key                      | Default value    | Description                                                                      |
-| ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
-| `basePath`               | `/`              | Root url for all blog posts                                                      |
-| `contentPath`            | `content/posts`  | Location of blog posts                                                           |
-| `assetPath`              | `content/assets` | Location of assets                                                               |
-| `mdxOtherwiseConfigured` | `false`          | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site. |
-| `excerptLength`          | `140`            | Length of the auto-generated excerpt of a blog post                              |
-| `imageMaxWidth`          | `1380`            | Set the max width of images in your blog posts. This applies to your featured image in frontmatter as well.                              |
+| Key                      | Default value    | Description                                                                                                 |
+| ------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| `basePath`               | `/`              | Root url for all blog posts                                                                                 |
+| `contentPath`            | `content/posts`  | Location of blog posts                                                                                      |
+| `assetPath`              | `content/assets` | Location of assets                                                                                          |
+| `mdxOtherwiseConfigured` | `false`          | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site.                            |
+| `excerptLength`          | `140`            | Length of the auto-generated excerpt of a blog post                                                         |
+| `imageMaxWidth`          | `1380`           | Set the max width of images in your blog posts. This applies to your featured image in frontmatter as well. |
 
 #### Example usage
 
@@ -96,7 +96,7 @@ module.exports = {
     description: `My site description...`,
     // Used for resolving images in social cards
     siteUrl: `https://example.com`,
-    // Used for social links in the root footer    
+    // Used for social links in the root footer
     social: [
       {
         name: `Twitter`,
@@ -127,7 +127,6 @@ The following are the defined blog post fields based on the node interface in th
 | image       | String   |
 | imageAlt    | String   |
 | socialImage | String   |
-
 
 ## Available components and styling
 

--- a/packages/gatsby-theme-blog-darkmode/README.md
+++ b/packages/gatsby-theme-blog-darkmode/README.md
@@ -2,12 +2,12 @@
 
 NOTE: This theme is designed to work as an add-on to `gatsby-theme-blog` and will not work without it!
 
-
 This theme enables a darkmode toggle in the header of your blog. It leverages `colors.mode.dark` in Theme UI which you can change by shadowing.
 
 ## Install instructions
 
 1. Install the dependencies
+
 ```shell
 npm install gatsby-theme-blog-darkmode gatsby-theme-blog
 ```
@@ -17,10 +17,7 @@ npm install gatsby-theme-blog-darkmode gatsby-theme-blog
 ```javascript
 // gatsby-config.js
 module.exports = {
-    plugins: [
-        `gatsby-theme-blog`,
-        `gatsby-theme-blog-darkmode`
-    ]
+  plugins: [`gatsby-theme-blog`, `gatsby-theme-blog-darkmode`],
 }
 ```
 
@@ -41,24 +38,20 @@ To shadow styles, create `src/gatsby-plugin-theme-ui/index.js`. Include an objec
 If you'd like to override only some styles you'll want to deepmerge.
 
 ```javascript
-import {merge} from "theme-ui"
+import { merge } from "theme-ui"
 import darkmode from "gatsby-theme-blog-darkmode/src/gatsby-plugin-theme-ui"
 
 export default merge(darkmode, {
-    colors: {
-        modes: {
-            dark: {
-                text: `tomato`
-            }
-        }
-    }
-}
-)
+  colors: {
+    modes: {
+      dark: {
+        text: `tomato`,
+      },
+    },
+  },
+})
 ```
 
 ## Migrating to `gatsby-theme-blog` 2.0
 
 Once you install this as a parallel theme be sure to update your shadowed paths. Files inside this theme, such as the sun and moon assets, will now be referenced inside the `gatsby-theme-blog-darkmode` directory.
-
-
-

--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -60,17 +60,17 @@ module.exports = {
 
 ### Theme options
 
-| Key                      | Default value    | Description                                                                                                                                                        |
-| ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `basePath`               | `/`              | Root url for all blog posts                                                                                                                                        |
-| `contentPath`            | `content/posts`  | Location of blog posts                                                                                                                                             |
-| `assetPath`              | `content/assets` | Location of assets                                                                                                                                                 |
-| `mdxOtherwiseConfigured` | `false`          | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site.                                                                                   |
-| `preset`  | `gatsby-theme-ui-preset`          | Theme UI compatible package name that will act as the base styles for your project. Be sure to install the package you're referencing. Set to `false` to ignore all presets and only use local styles. |
-| `prismPreset`  | `null`         | Theme UI compatible package name that will act as the prism syntax highlighting for your project. Be sure to install the package you're referencing. For themes in `@theme-ui/prism` the name will suffice, e.g. `prism-okaidia`. |
-| `excerptLength`          | `140`            | Length of the auto-generated excerpt of a blog post                                                                                                                |
-| `webfontURL`             | `''`             | URL for the webfont you'd like to include. Be sure that your local theme does not override it.                                                                     |
-| `imageMaxWidth`          | `1380`            | Set the max width of images in your blog posts. This applies to your featured image in frontmatter as well.                              |
+| Key                      | Default value            | Description                                                                                                                                                                                                                       |
+| ------------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `basePath`               | `/`                      | Root url for all blog posts                                                                                                                                                                                                       |
+| `contentPath`            | `content/posts`          | Location of blog posts                                                                                                                                                                                                            |
+| `assetPath`              | `content/assets`         | Location of assets                                                                                                                                                                                                                |
+| `mdxOtherwiseConfigured` | `false`                  | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site.                                                                                                                                                  |
+| `preset`                 | `gatsby-theme-ui-preset` | Theme UI compatible package name that will act as the base styles for your project. Be sure to install the package you're referencing. Set to `false` to ignore all presets and only use local styles.                            |
+| `prismPreset`            | `null`                   | Theme UI compatible package name that will act as the prism syntax highlighting for your project. Be sure to install the package you're referencing. For themes in `@theme-ui/prism` the name will suffice, e.g. `prism-okaidia`. |
+| `excerptLength`          | `140`                    | Length of the auto-generated excerpt of a blog post                                                                                                                                                                               |
+| `webfontURL`             | `''`                     | URL for the webfont you'd like to include. Be sure that your local theme does not override it.                                                                                                                                    |
+| `imageMaxWidth`          | `1380`                   | Set the max width of images in your blog posts. This applies to your featured image in frontmatter as well.                                                                                                                       |
 
 #### Example configuration
 
@@ -214,7 +214,6 @@ To update the styling for these highlights override the `.highlight` styles insi
 
 This theme comes equipt with [skip-nav](https://reacttraining.com/reach-ui/skip-nav/). Note that if you override `header.js` you'll need to add the `SkipNavLink` component yourself. Additionally, if you override `layout.js` you'll need to include `SkipNavContent` manually.
 
-
 ## Migration to 2.0
 
 The 2.0 release includes breaking changes. Note that many of the changes are related to the default styling in the blog theme. If you have no interest in additional flexibility with styles the 1.6 release may be sufficient as it includes new features without the breaking changes.
@@ -231,10 +230,10 @@ With the new version of `gatsby-plugin-theme-ui` there are a number of changes t
 
 **Change in shadow structure** - When shadowing files in `gatsby-plugin-theme-ui` the directory can no longer be nested inside the `gatsby-theme-blog` directory. It needs to be at the root level. Additionally, all content needs to be shadowed via `index.js`. You can make use of files like `colors.js` but they will not shadow unless explicitly exported from `index.js`.
 
-
-**Default deepmerge** - Any shadowed styles will deepmerge with the `gatsby-theme-blog` built-in styles automatically. 
+**Default deepmerge** - Any shadowed styles will deepmerge with the `gatsby-theme-blog` built-in styles automatically.
 
 If your previous code look like this:
+
 ```javascript
 import merge from "deepmerge"
 import defaultThemeColors from "gatsby-theme-blog/src/gatsby-plugin-theme-ui/colors"
@@ -251,6 +250,7 @@ export default merge(defaultThemeColors, {
 ```
 
 It should now look like this. Noting that the merge still occurs by default.
+
 ```javascript
 const darkBlue = `#007acc`
 const lightBlue = `#66E0FF`
@@ -267,31 +267,31 @@ If you did not merge in the official theme styles and instead overrode them you 
 
 ```javascript
 module.exports = {
-    plugins: [
-      {
-        resolve: `gatsby-theme-blog`,
-        options: {
-          preset: false
-        }
-      }
-    ]
+  plugins: [
+    {
+      resolve: `gatsby-theme-blog`,
+      options: {
+        preset: false,
+      },
+    },
+  ],
 }
 ```
 
-**No built in Typography.js** - Typography.js is no longer part of the default styling. If you'd like to add it locally follow the [Theme UI docs](https://theme-ui.com/packages/typography/#extending-the-typographyjs-theme) or note the code snippet below. The original theme used `typography-theme-wordpress-2016` and  also imported `typeface-montserrat` and `typeface-merriweather`. 
+**No built in Typography.js** - Typography.js is no longer part of the default styling. If you'd like to add it locally follow the [Theme UI docs](https://theme-ui.com/packages/typography/#extending-the-typographyjs-theme) or note the code snippet below. The original theme used `typography-theme-wordpress-2016` and also imported `typeface-montserrat` and `typeface-merriweather`.
 
 Another thing to keep in mind if you're pulling in typography for local shadowing is that the order of merging is different. The most common issue is that the spacing underneath code blocks is off. To fix that, include the following code in `src/gatsby-plugin-theme-ui/index.js`.
 
 ```javascript
-import { toTheme } from '@theme-ui/typography'
-import wp2016 from 'typography-theme-wordpress-2016'
-import {merge} from 'theme-ui'
+import { toTheme } from "@theme-ui/typography"
+import wp2016 from "typography-theme-wordpress-2016"
+import { merge } from "theme-ui"
 
 export default merge(toTheme(wp2016), {
   styles: {
     pre: {
-      margin: `0 0 2 0`
-    }
-  }
+      margin: `0 0 2 0`,
+    },
+  },
 })
 ```

--- a/packages/gatsby-theme-i18n/README.md
+++ b/packages/gatsby-theme-i18n/README.md
@@ -93,14 +93,12 @@ import { useLocalization } from "gatsby-theme-i18n"
 
 const Example = () => {
   const { locale, config, defaultLang } = useLocalization()
-  
+
   return (
     <div>
-        <div>Current locale: {locale}</div>
-        <div>Current defaultLang: {defaultLang}</div>
-        <pre>
-          {JSON.stringify(config, null, 2)}
-        </pre>
+      <div>Current locale: {locale}</div>
+      <div>Current defaultLang: {defaultLang}</div>
+      <pre>{JSON.stringify(config, null, 2)}</pre>
     </div>
   )
 }
@@ -121,7 +119,7 @@ import { LocalesList } from "gatsby-theme-i18n"
 const Example = () => {
   return (
     <div>
-        <LocalesList />
+      <LocalesList />
     </div>
   )
 }
@@ -142,7 +140,7 @@ import { LocalizedLink as Link } from "gatsby-theme-i18n"
 const Example = () => {
   return (
     <div>
-        <Link to="/page-2/">Link to second page</Link>
+      <Link to="/page-2/">Link to second page</Link>
     </div>
   )
 }
@@ -191,11 +189,7 @@ import { LocaleContext } from "gatsby-theme-i18n"
 const Example = () => {
   const locale = React.useContext(LocaleContext)
 
-  return (
-    <div>
-        Locale: {locale}
-    </div>
-  )
+  return <div>Locale: {locale}</div>
 }
 
 export default Example

--- a/packages/gatsby-theme-notes/README.md
+++ b/packages/gatsby-theme-notes/README.md
@@ -52,14 +52,14 @@ module.exports = {
 
 ### Options
 
-| Key                      | Default value    | Description                                                                      |
-| ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
-| `basePath`               | `/`              | Root url for all notes pages                                                     |
-| `contentPath`            | `/content/notes` | Location of notes content                                                        |
-| `mdxOtherwiseConfigured` | `false`          | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site. |
-| `homeText`               | `~`              | Root text for notes breadcrumb trail                                             |
-| `breadcrumbSeparator`    | `/`              | Separator for the breadcrumb trail                                               |
-| `preset`  | `gatsby-theme-ui-preset`          | Theme UI compatible package name that will act as the base styles for your project. Be sure to install the package you're referencing. Set to `false` to ignore all presets and only use local styles. |
+| Key                      | Default value            | Description                                                                                                                                                                                            |
+| ------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `basePath`               | `/`                      | Root url for all notes pages                                                                                                                                                                           |
+| `contentPath`            | `/content/notes`         | Location of notes content                                                                                                                                                                              |
+| `mdxOtherwiseConfigured` | `false`                  | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site.                                                                                                                       |
+| `homeText`               | `~`                      | Root text for notes breadcrumb trail                                                                                                                                                                   |
+| `breadcrumbSeparator`    | `/`                      | Separator for the breadcrumb trail                                                                                                                                                                     |
+| `preset`                 | `gatsby-theme-ui-preset` | Theme UI compatible package name that will act as the base styles for your project. Be sure to install the package you're referencing. Set to `false` to ignore all presets and only use local styles. |
 
 ### How Styles work
 


### PR DESCRIPTION
Prettier wasn't added to the dependencies and also wasn't running on pre-commit hooks.
I also modified the lerna config to be more like the one in https://github.com/gatsbyjs/gatsby/blob/master/lerna.json so that we get commits with the version bumps.

Lemme know if you had something else in mind