### PR TITLE
feat(gatsby-theme-i18n): Support localized 404 pages

### DIFF
--- a/packages/gatsby-theme-i18n/gatsby-node.js
+++ b/packages/gatsby-theme-i18n/gatsby-node.js
@@ -160,6 +160,7 @@ exports.onCreatePage = ({ page, actions }, themeOptions) => {
 
     // Check if the page is a localized 404
     if (newPage.path.match(/^\/[a-z]{2}\/404\/$/)) {
+      // Match all paths starting with this code (apart from other valid paths)
       newPage.matchPath = `/${locale.code}/*`
     }
 

--- a/packages/gatsby-theme-i18n/gatsby-node.js
+++ b/packages/gatsby-theme-i18n/gatsby-node.js
@@ -145,8 +145,8 @@ exports.onCreatePage = ({ page, actions }, themeOptions) => {
 
   const languages = getLanguages(defaultLang, configLocales, locales)
 
-  languages.forEach((locale) =>
-    createPage({
+  languages.forEach((locale) => {
+    const newPage = {
       ...page,
       path: localizedPath(defaultLang, locale.code, page.path),
       context: {
@@ -156,6 +156,13 @@ exports.onCreatePage = ({ page, actions }, themeOptions) => {
         originalPath,
         dateFormat: locale.dateFormat,
       },
-    })
-  )
+    }
+
+    // Check if the page is a localized 404
+    if (newPage.path.match(/^\/[a-z]{2}\/404\/$/)) {
+      newPage.matchPath = `/${locale.code}/*`
+    }
+
+    createPage(newPage)
+  })
 }

--- a/starters/example-lingui/i18n/lingui/_build/src/components/layout.js.json
+++ b/starters/example-lingui/i18n/lingui/_build/src/components/layout.js.json
@@ -1,5 +1,5 @@
 {
   "Home": {
-    "origin": [["src/components/layout.js", 14]]
+    "origin": [["src/components/layout.js", 15]]
   }
 }

--- a/starters/example-lingui/i18n/lingui/_build/src/pages/404.js.json
+++ b/starters/example-lingui/i18n/lingui/_build/src/pages/404.js.json
@@ -1,0 +1,5 @@
+{
+  "Not Found": {
+    "origin": [["src/pages/404.js", 11]]
+  }
+}

--- a/starters/example-lingui/i18n/lingui/_build/src/pages/index.js.json
+++ b/starters/example-lingui/i18n/lingui/_build/src/pages/index.js.json
@@ -1,23 +1,23 @@
 {
   "Hello World": {
-    "origin": [["src/pages/index.js", 12]]
-  },
-  "This is in the Index page": {
     "origin": [["src/pages/index.js", 13]]
   },
+  "This is in the Index page": {
+    "origin": [["src/pages/index.js", 16]]
+  },
   "Link to second page": {
-    "origin": [["src/pages/index.js", 15]]
+    "origin": [["src/pages/index.js", 20]]
   },
   "Link to third page": {
-    "origin": [["src/pages/index.js", 18]]
+    "origin": [["src/pages/index.js", 25]]
   },
   "Link to second page (german version)": {
-    "origin": [["src/pages/index.js", 21]]
+    "origin": [["src/pages/index.js", 30]]
   },
   "Link to index page (english version)": {
-    "origin": [["src/pages/index.js", 24]]
+    "origin": [["src/pages/index.js", 35]]
   },
   "Overview of languages": {
-    "origin": [["src/pages/index.js", 35]]
+    "origin": [["src/pages/index.js", 48]]
   }
 }

--- a/starters/example-lingui/i18n/lingui/_build/src/pages/page-3.js.json
+++ b/starters/example-lingui/i18n/lingui/_build/src/pages/page-3.js.json
@@ -1,14 +1,14 @@
 {
   "Third page": {
-    "origin": [["src/pages/page-3.js", 11]]
-  },
-  "This is the third page": {
     "origin": [["src/pages/page-3.js", 12]]
   },
+  "This is the third page": {
+    "origin": [["src/pages/page-3.js", 15]]
+  },
   "Link to second page": {
-    "origin": [["src/pages/page-3.js", 14]]
+    "origin": [["src/pages/page-3.js", 19]]
   },
   "Link to index page": {
-    "origin": [["src/pages/page-3.js", 17]]
+    "origin": [["src/pages/page-3.js", 24]]
   }
 }

--- a/starters/example-lingui/i18n/lingui/_build/src/templates/blog-template.js.json
+++ b/starters/example-lingui/i18n/lingui/_build/src/templates/blog-template.js.json
@@ -1,11 +1,11 @@
 {
   "Data": {
-    "origin": [["src/templates/blog-template.js", 12]]
+    "origin": [["src/templates/blog-template.js", 13]]
   },
   "This page hasn't been translated yet": {
-    "origin": [["src/templates/blog-template.js", 17]]
+    "origin": [["src/templates/blog-template.js", 20]]
   },
   "Context": {
-    "origin": [["src/templates/blog-template.js", 20]]
+    "origin": [["src/templates/blog-template.js", 25]]
   }
 }

--- a/starters/example-lingui/i18n/lingui/de/messages.js
+++ b/starters/example-lingui/i18n/lingui/de/messages.js
@@ -9,6 +9,7 @@
   },
   messages: {
     Home: "Startseite",
+    "Not Found": "Seite nicht gefunden",
     "Hello World": "Hallo Welt",
     "This is in the Index page": "Dies ist die Index Seite",
     "Link to second page": "Link zur zweiten Seite",

--- a/starters/example-lingui/i18n/lingui/de/messages.po
+++ b/starters/example-lingui/i18n/lingui/de/messages.po
@@ -13,59 +13,63 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/layout.js:14
+#: src/components/layout.js:15
 msgid "Home"
 msgstr "Startseite"
 
-#: src/pages/index.js:12
+#: src/pages/404.js:11
+msgid "Not Found"
+msgstr "Seite nicht gefunden"
+
+#: src/pages/index.js:13
 msgid "Hello World"
 msgstr "Hallo Welt"
 
-#: src/pages/index.js:13
+#: src/pages/index.js:16
 msgid "This is in the Index page"
 msgstr "Dies ist die Index Seite"
 
-#: src/pages/index.js:15
-#: src/pages/page-3.js:14
+#: src/pages/index.js:20
+#: src/pages/page-3.js:19
 msgid "Link to second page"
 msgstr "Link zur zweiten Seite"
 
-#: src/pages/index.js:18
+#: src/pages/index.js:25
 msgid "Link to third page"
 msgstr "Link zur dritten Seite"
 
-#: src/pages/index.js:21
+#: src/pages/index.js:30
 msgid "Link to second page (german version)"
 msgstr "Link zur zweiten Seite (Deutsche Version)"
 
-#: src/pages/index.js:24
+#: src/pages/index.js:35
 msgid "Link to index page (english version)"
 msgstr "Link zur Index Seite (Englische Version)"
 
-#: src/pages/index.js:35
+#: src/pages/index.js:48
 msgid "Overview of languages"
 msgstr "Übersicht der Sprachen"
 
-#: src/pages/page-3.js:11
+#: src/pages/page-3.js:12
 msgid "Third page"
 msgstr "Dritte Seite"
 
-#: src/pages/page-3.js:12
+#: src/pages/page-3.js:15
 msgid "This is the third page"
 msgstr "Dies ist die dritte Seite"
 
-#: src/pages/page-3.js:17
+#: src/pages/page-3.js:24
 msgid "Link to index page"
 msgstr "Link zur Index Seite"
 
-#: src/templates/blog-template.js:12
+#: src/templates/blog-template.js:13
 msgid "Data"
 msgstr "Daten"
 
-#: src/templates/blog-template.js:17
+#: src/templates/blog-template.js:20
 msgid "This page hasn't been translated yet"
 msgstr "Diese Seite wurde noch nicht übersetzt"
 
-#: src/templates/blog-template.js:20
+#: src/templates/blog-template.js:25
 msgid "Context"
 msgstr "Seiten Context"

--- a/starters/example-lingui/i18n/lingui/en/messages.js
+++ b/starters/example-lingui/i18n/lingui/en/messages.js
@@ -19,6 +19,7 @@
   },
   messages: {
     Home: "Home",
+    "Not Found": "Page not found",
     "Hello World": "Hello World",
     "This is in the Index page": "This is in the Index page",
     "Link to second page": "Link to second page",

--- a/starters/example-lingui/i18n/lingui/en/messages.po
+++ b/starters/example-lingui/i18n/lingui/en/messages.po
@@ -13,59 +13,63 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/layout.js:14
+#: src/components/layout.js:15
 msgid "Home"
 msgstr "Home"
 
-#: src/pages/index.js:12
+#: src/pages/404.js:11
+msgid "Not Found"
+msgstr "Page not found"
+
+#: src/pages/index.js:13
 msgid "Hello World"
 msgstr "Hello World"
 
-#: src/pages/index.js:13
+#: src/pages/index.js:16
 msgid "This is in the Index page"
 msgstr "This is in the Index page"
 
-#: src/pages/index.js:15
-#: src/pages/page-3.js:14
+#: src/pages/index.js:20
+#: src/pages/page-3.js:19
 msgid "Link to second page"
 msgstr "Link to second page"
 
-#: src/pages/index.js:18
+#: src/pages/index.js:25
 msgid "Link to third page"
 msgstr "Link to third page"
 
-#: src/pages/index.js:21
+#: src/pages/index.js:30
 msgid "Link to second page (german version)"
 msgstr "Link to second page (german version)"
 
-#: src/pages/index.js:24
+#: src/pages/index.js:35
 msgid "Link to index page (english version)"
 msgstr "Link to index page (english version)"
 
-#: src/pages/index.js:35
+#: src/pages/index.js:48
 msgid "Overview of languages"
 msgstr "Overview of languages"
 
-#: src/pages/page-3.js:11
+#: src/pages/page-3.js:12
 msgid "Third page"
 msgstr "Third page"
 
-#: src/pages/page-3.js:12
+#: src/pages/page-3.js:15
 msgid "This is the third page"
 msgstr "This is the third page"
 
-#: src/pages/page-3.js:17
+#: src/pages/page-3.js:24
 msgid "Link to index page"
 msgstr "Link to index page"
 
-#: src/templates/blog-template.js:12
+#: src/templates/blog-template.js:13
 msgid "Data"
 msgstr "Data"
 
-#: src/templates/blog-template.js:17
+#: src/templates/blog-template.js:20
 msgid "This page hasn't been translated yet"
 msgstr "This page hasn't been translated yet"
 
-#: src/templates/blog-template.js:20
+#: src/templates/blog-template.js:25
 msgid "Context"
 msgstr "Context"

--- a/starters/example-lingui/src/pages/404.js
+++ b/starters/example-lingui/src/pages/404.js
@@ -1,14 +1,15 @@
 import * as React from "react"
-import { useIntl } from "react-intl"
+import { Trans } from "@lingui/macro"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
 const NotFound = () => {
-  const intl = useIntl()
   return (
     <Layout>
       <SEO title="404" />
-      <h1>{intl.formatMessage({ id: "notFound" })}</h1>
+      <h1>
+        <Trans>Not Found</Trans>
+      </h1>
     </Layout>
   )
 }

--- a/starters/example-react-i18next/gatsby-config.js
+++ b/starters/example-react-i18next/gatsby-config.js
@@ -33,7 +33,7 @@ module.exports = {
       options: {
         locales: `./i18n/react-i18next`,
         i18nextOptions: {
-          ns: ["translation", "blog"],
+          ns: ["translation", "blog", "404"],
         },
       },
     },

--- a/starters/example-react-i18next/i18n/react-i18next/de/404.json
+++ b/starters/example-react-i18next/i18n/react-i18next/de/404.json
@@ -1,0 +1,3 @@
+{
+  "notFound": "Pagina niet gevonden"
+}

--- a/starters/example-react-i18next/i18n/react-i18next/de/404.json
+++ b/starters/example-react-i18next/i18n/react-i18next/de/404.json
@@ -1,3 +1,3 @@
 {
-  "notFound": "Pagina niet gevonden"
+  "notFound": "Seite nicht gefunden"
 }

--- a/starters/example-react-i18next/i18n/react-i18next/en/404.json
+++ b/starters/example-react-i18next/i18n/react-i18next/en/404.json
@@ -1,0 +1,3 @@
+{
+  "notFound": "Page not found"
+}

--- a/starters/example-react-i18next/src/pages/404.js
+++ b/starters/example-react-i18next/src/pages/404.js
@@ -1,0 +1,16 @@
+import * as React from "react"
+import { useTranslation } from "react-i18next"
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const NotFound = () => {
+  const { t } = useTranslation("404")
+  return (
+    <Layout>
+      <SEO title="404" />
+      <h1>{t("notFound")}</h1>
+    </Layout>
+  )
+}
+
+export default NotFound

--- a/starters/example-react-intl/i18n/react-intl/de.json
+++ b/starters/example-react-intl/i18n/react-intl/de.json
@@ -9,5 +9,6 @@
   "overviewLang": "Übersicht der Sprachen",
   "thirdPage": "Dritte Seite",
   "thirdNote": "Dies ist die dritte Seite",
-  "home": "Startseite"
+  "home": "Startseite",
+  "notFound": "Pagina niet gevonden"
 }

--- a/starters/example-react-intl/i18n/react-intl/de.json
+++ b/starters/example-react-intl/i18n/react-intl/de.json
@@ -10,5 +10,5 @@
   "thirdPage": "Dritte Seite",
   "thirdNote": "Dies ist die dritte Seite",
   "home": "Startseite",
-  "notFound": "Pagina niet gevonden"
+  "notFound": "Seite nicht gefunden"
 }

--- a/starters/example-react-intl/i18n/react-intl/en.json
+++ b/starters/example-react-intl/i18n/react-intl/en.json
@@ -9,5 +9,6 @@
   "overviewLang": "Overview of languages",
   "thirdPage": "Third page",
   "thirdNote": "This is the third page",
-  "home": "Home"
+  "home": "Home",
+  "notFound": "Page not found"
 }

--- a/starters/example-react-intl/src/pages/404.js
+++ b/starters/example-react-intl/src/pages/404.js
@@ -1,0 +1,16 @@
+import * as React from "react"
+import { useIntl } from "react-intl"
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const Page3 = () => {
+  const intl = useIntl()
+  return (
+    <Layout>
+      <SEO title="404" />
+      <h1>{intl.formatMessage({ id: "notFound" })}</h1>
+    </Layout>
+  )
+}
+
+export default Page3


### PR DESCRIPTION
As mentioned on #43, the i18n theme currently doesn't support having localized 404 pages, this PR intends to add it.

I added examples both for react-i18next and react-intl.

This is my first PR so if there's anything I should take into consideration before going forward, please let me know.