### PR TITLE
Revert "change seo title from "Home" to {siteTitle}"

### DIFF
--- a/packages/gatsby-theme-blog/src/components/posts.js
+++ b/packages/gatsby-theme-blog/src/components/posts.js
@@ -7,7 +7,7 @@ import PostList from "./post-list"
 
 const Posts = ({ location, posts, siteTitle, socialLinks }) => (
   <Layout location={location} title={siteTitle}>
-    <SEO title={siteTitle} />
+    <SEO title="Home" />
     <main>
       <PostList posts={posts} />
     </main>


### PR DESCRIPTION
Reverts gatsbyjs/themes#44

I would like to revert this commit 
because I had not noticed the following implementation.

https://github.com/gatsbyjs/themes/blob/91961d0660321a67a43a57666c4819261cfe92b1/packages/gatsby-theme-blog/src/components/seo.js#L41

I am sorry.