### PR TITLE
feat(gatsby-theme-i18n): Localized matchPath & LocalizedRouter

### DIFF
--- a/packages/gatsby-theme-i18n/README.md
+++ b/packages/gatsby-theme-i18n/README.md
@@ -149,6 +149,28 @@ const Example = () => {
 export default Example
 ```
 
+#### LocalizedRouter
+
+Provides a `<Router />` from `@reach/router` that prefixes the `basePath` prop with the current locale.
+
+Example:
+
+```js
+import React from "react"
+import { LocalizedRouter } from "gatsby-theme-i18n"
+import Detail from "../components/detail"
+
+const App = () => {
+  return (
+    <LocalizedRouter basePath="/app">
+      <Detail path="/:id" />
+    </LocalizedRouter>
+  )
+}
+
+export default App
+```
+
 #### MdxLink
 
 This is a component specifically for MDX to replace the normal anchor tag. This way local links to other files are automatically localized (as it uses `LocalizedLink` behind the scenes).

--- a/packages/gatsby-theme-i18n/README.md
+++ b/packages/gatsby-theme-i18n/README.md
@@ -70,10 +70,11 @@ You can also see an [official example](https://github.com/gatsbyjs/themes/tree/m
 
 ### Theme options
 
-| Key           | Default Value | Description                                                                                     |
-| ------------- | ------------- | ----------------------------------------------------------------------------------------------- |
-| `defaultLang` | `en`          | The locale that is your default language. For this language no prefixed routes will be created. |
-| `configPath`  | none          | Path to the config file                                                                         |
+| Key           | Default Value | Description                                                                                                         |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `defaultLang` | `en`          | The locale that is your default language. For this language no prefixed routes will be created.                     |
+| `configPath`  | none          | Path to the config file                                                                                             |
+| `locales`     | `null`        | A string of locales (divided by spaces) to only build a subset of the locales defined in `configPath`, e.g. `en de` |
 
 You can pass additional options in as they'll be forwarded to the plugin. You can query all options in GraphQL on the `themeI18N` type.
 

--- a/packages/gatsby-theme-i18n/README.md
+++ b/packages/gatsby-theme-i18n/README.md
@@ -1,6 +1,6 @@
 # gatsby-theme-i18n
 
-A Gatsby theme for providing internationalization support to your Gatsby site by taking in a configuration file and creating prefixed, enriched pages for each language. Also adds `<link rel="alternate" />` tags to your `<head>`, exposes useful React components and hooks.
+A Gatsby theme for providing internationalization support to your Gatsby site by taking in a configuration file and creating prefixed, enriched pages for each language (including client-only pages that have a matchPath). Also adds `<link rel="alternate" />` tags to your `<head>`, exposes useful React components and hooks.
 
 ## Installation
 

--- a/packages/gatsby-theme-i18n/gatsby-node.js
+++ b/packages/gatsby-theme-i18n/gatsby-node.js
@@ -149,6 +149,7 @@ exports.onCreatePage = ({ page, actions }, themeOptions) => {
     createPage({
       ...page,
       path: localizedPath(defaultLang, locale.code, page.path),
+      matchPath: page.matchPath ? localizedPath(defaultLang, locale.code, page.matchPath) : page.matchPath,
       context: {
         ...page.context,
         locale: locale.code,

--- a/packages/gatsby-theme-i18n/gatsby-node.js
+++ b/packages/gatsby-theme-i18n/gatsby-node.js
@@ -149,7 +149,9 @@ exports.onCreatePage = ({ page, actions }, themeOptions) => {
     const newPage = {
       ...page,
       path: localizedPath(defaultLang, locale.code, page.path),
-      matchPath: page.matchPath ? localizedPath(defaultLang, locale.code, page.matchPath) : page.matchPath,
+      matchPath: page.matchPath
+        ? localizedPath(defaultLang, locale.code, page.matchPath)
+        : page.matchPath,
       context: {
         ...page.context,
         locale: locale.code,

--- a/packages/gatsby-theme-i18n/index.js
+++ b/packages/gatsby-theme-i18n/index.js
@@ -1,5 +1,6 @@
 export { LocaleContext, LocaleProvider } from "./src/context"
 export { MdxLink } from "./src/components/mdx-link"
 export { LocalizedLink } from "./src/components/localized-link"
+export { LocalizedRouter } from "./src/components/localized-router"
 export { LocalesList } from "./src/components/locales-list"
 export { useLocalization } from "./src/hooks/use-localization"

--- a/packages/gatsby-theme-i18n/src/components/locales-list.js
+++ b/packages/gatsby-theme-i18n/src/components/locales-list.js
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { useLocalization } from "../hooks/use-localization"
 
-const LocalesList = () => {
+export const LocalesList = () => {
   const { config } = useLocalization()
 
   return (
@@ -14,5 +14,3 @@ const LocalesList = () => {
     </ul>
   )
 }
-
-export { LocalesList }

--- a/packages/gatsby-theme-i18n/src/components/localized-router.js
+++ b/packages/gatsby-theme-i18n/src/components/localized-router.js
@@ -1,0 +1,14 @@
+import * as React from "react"
+import { Router } from "@reach/router"
+import { useLocalization } from "../hooks/use-localization"
+
+export const LocalizedRouter = ({ basePath, children, ...props }) => {
+  const { localizedPath, locale, defaultLang } = useLocalization()
+  const path = localizedPath(defaultLang, locale, basePath)
+
+  return (
+    <Router basepath={path} {...props}>
+      {children}
+    </Router>
+  )
+}

--- a/packages/gatsby-theme-i18n/src/hooks/use-localization.js
+++ b/packages/gatsby-theme-i18n/src/hooks/use-localization.js
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { LocaleContext } from "../context"
 import { graphql, useStaticQuery } from "gatsby"
+import { localizedPath } from "../helpers"
 
 const useLocalization = () => {
   const locale = React.useContext(LocaleContext)
@@ -26,6 +27,7 @@ const useLocalization = () => {
     locale,
     defaultLang,
     config,
+    localizedPath,
   }
 }
 

--- a/starters/example-i18n/gatsby-config.js
+++ b/starters/example-i18n/gatsby-config.js
@@ -33,7 +33,7 @@ module.exports = {
       resolve: `gatsby-theme-i18n`,
       options: {
         defaultLang: `en`,
-        locales: process.env.LOCALES,
+        locales: process.env.LOCALES || `en de`,
         configPath: require.resolve(`./i18n/config.json`),
       },
     },

--- a/starters/example-i18n/gatsby-config.js
+++ b/starters/example-i18n/gatsby-config.js
@@ -24,6 +24,10 @@ module.exports = {
         name: `blog`,
       },
     },
+    {
+      resolve: `gatsby-plugin-create-client-paths`,
+      options: { prefixes: [`/app/*`] },
+    },
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-theme-i18n`,

--- a/starters/example-i18n/package.json
+++ b/starters/example-i18n/package.json
@@ -15,6 +15,7 @@
     "@mdx-js/mdx": "^1.6.14",
     "@mdx-js/react": "^1.6.14",
     "gatsby": "^2.24.10",
+    "gatsby-plugin-create-client-paths": "^2.3.10",
     "gatsby-plugin-mdx": "^1.2.28",
     "gatsby-plugin-react-helmet": "^3.3.10",
     "gatsby-source-filesystem": "^2.3.22",

--- a/starters/example-i18n/src/components/name.js
+++ b/starters/example-i18n/src/components/name.js
@@ -1,0 +1,16 @@
+import * as React from "react"
+import Layout from "./layout"
+import { LocalizedLink } from "gatsby-theme-i18n"
+
+const Name = ({ name, locale }) => (
+  <Layout>
+    <h1>
+      {name} & {locale}
+    </h1>
+    <p>
+      <LocalizedLink to="/">Link to index page</LocalizedLink>
+    </p>
+  </Layout>
+)
+
+export default Name

--- a/starters/example-i18n/src/pages/app.js
+++ b/starters/example-i18n/src/pages/app.js
@@ -1,0 +1,15 @@
+import React from "react"
+import { LocalizedRouter, useLocalization } from "gatsby-theme-i18n"
+import Name from "../components/name"
+
+const App = () => {
+  const { locale } = useLocalization()
+
+  return (
+    <LocalizedRouter basePath="/app">
+      <Name path="/:name" locale={locale} />
+    </LocalizedRouter>
+  )
+}
+
+export default App

--- a/starters/example-i18n/src/pages/index.js
+++ b/starters/example-i18n/src/pages/index.js
@@ -26,6 +26,9 @@ const Index = ({ data }) => {
           Link to index page (english version)
         </LocalizedLink>
       </p>
+      <p>
+        <LocalizedLink to="/app/gatsby">Link to client-only page</LocalizedLink>
+      </p>
       <ul>
         {data.allFile.nodes.map(({ childMdx: node }) => (
           <li key={node.frontmatter.slug}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8081,6 +8081,13 @@ gatsby-plugin-compile-es6-packages@^2.1.0:
     "@babel/runtime" "^7.0.0"
     regex-escape "^3.4.8"
 
+gatsby-plugin-create-client-paths@^2.3.10:
+  version "2.3.10"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-create-client-paths/-/gatsby-plugin-create-client-paths-2.3.10.tgz#69b1a81c8df3cfaa0e148858f708de25fbdbbb46"
+  integrity sha512-Uke6xrsDGotbY2/RuyD3Lk6U3h27R2HsU0D/LaPkOEkOr9M6LRVk1Tp3CF1VBtklv4dyRig+eNqcia8oKjEjPw==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+
 gatsby-plugin-emotion@^4.3.10:
   version "4.3.10"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.3.10.tgz#569e9489837fa0f55db0a0264efda7f3c6c4a4cd"


### PR DESCRIPTION
https://www.gatsbyjs.com/docs/gatsby-internals-terminology/#matchpath

the matchPath prop on the page being created was not being modified (by adding /langCode/ to the start of matchPath)

This would cause client pages not being properly found and when accessing `/langCode/client-page-url`