### PR TITLE
feat(gatsby-theme-i18n): Add "prefixDefault" option

### DIFF
--- a/packages/gatsby-theme-i18n/README.md
+++ b/packages/gatsby-theme-i18n/README.md
@@ -73,7 +73,7 @@ You can also see an [official example](https://github.com/gatsbyjs/themes/tree/m
 | Key             | Default Value | Description                                                                                                                               |
 | --------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `defaultLang`   | `en`          | The locale that is your default language. For this language no prefixed routes will be created unless you set the option `prefixDefault`. |
-| `prefixDefault` | `false`       | Prefix all routes with the default language                                                                                               |
+| `prefixDefault` | `false`       | All routes will be prefixed, including the `defaultLang`                                                                                  |
 | `configPath`    | none          | Path to the config file                                                                                                                   |
 | `locales`       | `null`        | A string of locales (divided by spaces) to only build a subset of the locales defined in `configPath`, e.g. `en de`                       |
 

--- a/packages/gatsby-theme-i18n/README.md
+++ b/packages/gatsby-theme-i18n/README.md
@@ -70,11 +70,12 @@ You can also see an [official example](https://github.com/gatsbyjs/themes/tree/m
 
 ### Theme options
 
-| Key           | Default Value | Description                                                                                                         |
-| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `defaultLang` | `en`          | The locale that is your default language. For this language no prefixed routes will be created.                     |
-| `configPath`  | none          | Path to the config file                                                                                             |
-| `locales`     | `null`        | A string of locales (divided by spaces) to only build a subset of the locales defined in `configPath`, e.g. `en de` |
+| Key             | Default Value | Description                                                                                                                               |
+| --------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `defaultLang`   | `en`          | The locale that is your default language. For this language no prefixed routes will be created unless you set the option `prefixDefault`. |
+| `prefixDefault` | `false`       | Prefix all routes with the default language                                                                                               |
+| `configPath`    | none          | Path to the config file                                                                                                                   |
+| `locales`       | `null`        | A string of locales (divided by spaces) to only build a subset of the locales defined in `configPath`, e.g. `en de`                       |
 
 You can pass additional options in as they'll be forwarded to the plugin. You can query all options in GraphQL on the `themeI18N` type.
 

--- a/packages/gatsby-theme-i18n/src/components/localized-link.js
+++ b/packages/gatsby-theme-i18n/src/components/localized-link.js
@@ -4,8 +4,18 @@ import { localizedPath } from "../helpers"
 import { useLocalization } from "../hooks/use-localization"
 
 export const LocalizedLink = ({ to, language, ...props }) => {
-  const { defaultLang, locale } = useLocalization()
+  const { defaultLang, prefixDefault, locale } = useLocalization()
   const linkLocale = language || locale
 
-  return <Link {...props} to={localizedPath(defaultLang, linkLocale, to)} />
+  return (
+    <Link
+      {...props}
+      to={localizedPath({
+        defaultLang,
+        prefixDefault,
+        locale: linkLocale,
+        path: to,
+      })}
+    />
+  )
 }

--- a/packages/gatsby-theme-i18n/src/components/localized-router.js
+++ b/packages/gatsby-theme-i18n/src/components/localized-router.js
@@ -3,8 +3,18 @@ import { Router } from "@reach/router"
 import { useLocalization } from "../hooks/use-localization"
 
 export const LocalizedRouter = ({ basePath, children, ...props }) => {
-  const { localizedPath, locale, defaultLang } = useLocalization()
-  const path = localizedPath(defaultLang, locale, basePath)
+  const {
+    localizedPath,
+    locale,
+    defaultLang,
+    prefixDefault,
+  } = useLocalization()
+  const path = localizedPath({
+    defaultLang,
+    prefixDefault,
+    locale,
+    path: basePath,
+  })
 
   return (
     <Router basepath={path} {...props}>

--- a/packages/gatsby-theme-i18n/src/helpers.js
+++ b/packages/gatsby-theme-i18n/src/helpers.js
@@ -2,9 +2,9 @@ function isDefaultLang(locale, defaultLang) {
   return locale === defaultLang
 }
 
-function localizedPath(defaultLang, locale, path) {
+function localizedPath({ defaultLang, prefixDefault, locale, path }) {
   // The default language isn't prefixed
-  if (isDefaultLang(locale, defaultLang)) {
+  if (isDefaultLang(locale, defaultLang) && !prefixDefault) {
     return path
   }
 
@@ -21,7 +21,7 @@ function localizedPath(defaultLang, locale, path) {
   return `/${locale}${path}`
 }
 
-function getLanguages(defaultLang, locales, localeStr) {
+function getLanguages({ locales, localeStr }) {
   // If "localeStr" is not defined, return the list of locales from the i18n config file
   if (!localeStr) {
     return locales
@@ -45,7 +45,12 @@ function getLanguages(defaultLang, locales, localeStr) {
   return langs
 }
 
+function getDefaultLanguage({ locales, defaultLang }) {
+  return locales.find((locale) => locale.code === defaultLang)
+}
+
 module.exports = {
   localizedPath,
   getLanguages,
+  getDefaultLanguage,
 }

--- a/packages/gatsby-theme-i18n/src/hooks/use-localization.js
+++ b/packages/gatsby-theme-i18n/src/hooks/use-localization.js
@@ -6,11 +6,12 @@ import { localizedPath } from "../helpers"
 const useLocalization = () => {
   const locale = React.useContext(LocaleContext)
   const {
-    themeI18N: { defaultLang, config },
+    themeI18N: { defaultLang, prefixDefault, config },
   } = useStaticQuery(graphql`
     query LocalizationConfigQuery {
       themeI18N {
         defaultLang
+        prefixDefault
         config {
           code
           hrefLang
@@ -26,6 +27,7 @@ const useLocalization = () => {
   return {
     locale,
     defaultLang,
+    prefixDefault,
     config,
     localizedPath,
   }

--- a/packages/gatsby-theme-i18n/utils/default-options.js
+++ b/packages/gatsby-theme-i18n/utils/default-options.js
@@ -5,6 +5,9 @@ function withDefaults(themeOptions) {
     ...themeOptions,
     configPath: themeOptions.configPath,
     defaultLang: themeOptions.defaultLang || defaultLang,
+    prefixDefault: themeOptions.prefixDefault
+      ? themeOptions.prefixDefault
+      : false,
     locales: themeOptions.locales || null,
   }
 }

--- a/starters/example-i18n/src/components/name.js
+++ b/starters/example-i18n/src/components/name.js
@@ -1,9 +1,11 @@
 import * as React from "react"
 import Layout from "./layout"
 import { LocalizedLink } from "gatsby-theme-i18n"
+import SEO from "./seo"
 
 const Name = ({ name, locale }) => (
   <Layout>
+    <SEO title={name} />
     <h1>
       {name} & {locale}
     </h1>

--- a/starters/example-i18n/src/pages/404.js
+++ b/starters/example-i18n/src/pages/404.js
@@ -1,0 +1,19 @@
+import * as React from "react"
+import { LocalizedLink } from "gatsby-theme-i18n"
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const NotFound = () => {
+  return (
+    <Layout>
+      <SEO title="404 - Page Not Found" />
+      <h1>404</h1>
+      <p>Page Not Found</p>
+      <p>
+        <LocalizedLink to="/">Link to index page</LocalizedLink>
+      </p>
+    </Layout>
+  )
+}
+
+export default NotFound


### PR DESCRIPTION
You can try this out by installing the canary `1.0.5-defaultprefix` on npm.

---

This adds a `prefixDefault` option to `gatsby-theme-i18n`. Currently this will create `/en/` instead of `/` if e.g. `en` is the default language.