### PR TITLE
fix(gatsby-theme-notes): remove deprecated theme-ui components from notes-theme

### DIFF
--- a/packages/gatsby-theme-notes/src/components/layout.js
+++ b/packages/gatsby-theme-notes/src/components/layout.js
@@ -1,7 +1,6 @@
 import React from "react"
 import { Global } from "@emotion/core"
-import { css } from "theme-ui"
-import { Layout, Main, Container } from "theme-ui"
+import { css, Box } from "theme-ui"
 import Footer from "./footer"
 
 export default (props) => (
@@ -17,13 +16,25 @@ export default (props) => (
         },
       })}
     />
-    <Layout>
-      <Main>
-        <Container>
+    <Box
+      css={css({
+        minHeight: `100vh`,
+        display: `flex`,
+        flexDirection: `column`,
+      })}
+    >
+      <Box as="main">
+        <Box
+          p={[5]}
+          css={css({
+            display: `flex`,
+            flexDirection: `column`,
+          })}
+        >
           {props.children}
           <Footer />
-        </Container>
-      </Main>
-    </Layout>
+        </Box>
+      </Box>
+    </Box>
   </>
 )


### PR DESCRIPTION
## Description

The notes theme had outdated `theme-ui/components` composed together to create its layout component. The older versions of `gatsby-theme-notes` had no issues until 2.0.X, when the theme upgraded the versions of theme-ui (which are now on alpha 0.4 , instead of 0.2 which used the older version of theme-ui components). 

Components like Layout and Main are no longer exported by theme-ui, and thus need to be replaced. ([release notes with this info](https://github.com/system-ui/theme-ui/blob/master/CHANGELOG.md#v030-2020-01-22))

This should resolve the ability to manually add the theme to a new site.

## Related Issue

Fixes https://github.com/gatsbyjs/themes/issues/59