### PR TITLE
chore(gatsby-theme-notes): add small e2e tests to notes theme

### DIFF
--- a/cypress/e2e/note.js
+++ b/cypress/e2e/note.js
@@ -1,0 +1,10 @@
+describe(`a note`, () => {
+  it(`should render inside the layout`, () => {
+    cy.visit(`/notes/hello`)
+    cy.contains(`Shadowed Site Title`).should(`exist`)
+  })
+
+  it(`should render markdown link`, () => {
+    cy.contains(`homepage`).click()
+  })
+})

--- a/cypress/e2e/notes-listing.js
+++ b/cypress/e2e/notes-listing.js
@@ -1,0 +1,10 @@
+describe(`notes listing page`, () => {
+  it(`should render a list of notes`, () => {
+    cy.visit(`/notes/`)
+    cy.findByText(`example-dir`).should(`exist`)
+  })
+
+  it(`should render inside the layout`, () => {
+    cy.contains(`Shadowed Site Title`).should(`exist`)
+  })
+})

--- a/starters/theme/content/notes/hello.mdx
+++ b/starters/theme/content/notes/hello.mdx
@@ -1,1 +1,19 @@
 # Hello!
+
+Here is some content written in MDX.
+
+See the [homepage](/)
+
+- here are
+- a few
+- bullet points
+
+---
+
+Some **bold** and _underlined_ text.
+
+A numbered list:
+
+1. one
+2. two
+3. three


### PR DESCRIPTION
While working on #76, I found the problem breaking `gatsby-theme-notes` ended up being a runtime error that wasn't caught by any tests. @laurieontech (in all her kindness) offered to pair with me for a bit to give me some context and help me get started writing some tests.

This PR adds a few more testings specs to verify the pages actually load and render within the layout.