### PR TITLE
Add frontmatter imageAlt to fieldData

### DIFF
--- a/packages/gatsby-theme-blog-core/gatsby-node.js
+++ b/packages/gatsby-theme-blog-core/gatsby-node.js
@@ -198,6 +198,7 @@ exports.onCreateNode = async (
       slug,
       date: node.frontmatter.date,
       image: node.frontmatter.image,
+      imageAlt: node.frontmatter.imageAlt,
       socialImage: node.frontmatter.socialImage,
     }
 


### PR DESCRIPTION
This field is used in `gatsby-theme-blog` but its currently always `undefined`.

https://github.com/gatsbyjs/themes/blob/master/packages/gatsby-theme-blog/src/components/post.js#L32