### PR TITLE
Fix incorrect path in documentation

### DIFF
--- a/packages/gatsby-theme-blog-core/README.md
+++ b/packages/gatsby-theme-blog-core/README.md
@@ -130,6 +130,6 @@ The following are the defined blog post fields based on the node interface in th
 
 ## Available components and styling
 
-There are some existing components that you can import and use. Reference the full path to do so, e.g. `gatsby-blog-theme/src/components/post`.
+There are some existing components that you can import and use. Reference the full path to do so, e.g. `gatsby-blog-theme-core/src/components/post`.
 
 Also note that there are classNames on elements in these components allowing you to target them with styles.


### PR DESCRIPTION
The `README` in `gatsby-blog-theme-core` suggests importing a component from `gatsby-blog-theme`, which would result in an error.

This PR updates the documentation to include the correct import path.