### PR TITLE
fix(gatsby-theme-i18n-react-i18next): default options typo

### DIFF
--- a/packages/gatsby-theme-i18n-react-i18next/utils/default-options.js
+++ b/packages/gatsby-theme-i18n-react-i18next/utils/default-options.js
@@ -10,7 +10,7 @@ function withDefaults(themeOptions) {
       fallbackLng,
       interpolation: {
         escapeValue: false,
-        ...themeOptions.i18nextOptions.escapeValue,
+        ...themeOptions.i18nextOptions.interpolation,
       },
       initImmediate: false,
       ...themeOptions.i18nextOptions,


### PR DESCRIPTION
Small typo fix in default options