### PR TITLE
fix: fix hrefLang x-default tag

### DIFF
--- a/packages/gatsby-theme-i18n/src/components/seo.js
+++ b/packages/gatsby-theme-i18n/src/components/seo.js
@@ -4,7 +4,7 @@ import { useStaticQuery, graphql, withPrefix } from "gatsby"
 import { useLocalization } from "../hooks/use-localization"
 
 const SEO = ({ location, pageContext }) => {
-  const { locale, config, defaultLang } = useLocalization()
+  const { locale, config, prefixDefault, defaultLang } = useLocalization()
   const data = useStaticQuery(graphql`
     query LocalizationSEOQuery {
       site {
@@ -20,11 +20,12 @@ const SEO = ({ location, pageContext }) => {
   return (
     <Helmet>
       <html lang={pageContext.hrefLang} />
-      <link rel="alternate" hrefLang="x-default" href={`${defaultSiteUrl}${
-        pageContext.originalPath === withPrefix(`/`)
-          ? ``
-          : pageContext.originalPath
-      }`} />
+        <link rel="alternate" hrefLang="x-default" href={`${defaultSiteUrl}${
+            prefixDefault ? `/${defaultLang}` : ``}${
+            pageContext.originalPath === withPrefix(`/`)
+                ? ``
+                : pageContext.originalPath
+        }`} />
       <link
         rel="alternate"
         hrefLang={pageContext.hrefLang}

--- a/packages/gatsby-theme-i18n/src/components/seo.js
+++ b/packages/gatsby-theme-i18n/src/components/seo.js
@@ -20,7 +20,11 @@ const SEO = ({ location, pageContext }) => {
   return (
     <Helmet>
       <html lang={pageContext.hrefLang} />
-      <link rel="alternate" hrefLang="x-default" href={defaultSiteUrl} />
+      <link rel="alternate" hrefLang="x-default" href={`${defaultSiteUrl}${
+        pageContext.originalPath === withPrefix(`/`)
+          ? ``
+          : pageContext.originalPath
+      }`} />
       <link
         rel="alternate"
         hrefLang={pageContext.hrefLang}


### PR DESCRIPTION
Hi, there is a SEO problem in the x-default link tag. As you can see here x-default is referred to defaultSiteUrl without path, so hrefLang will be wrong in the pages which are not the home page.

I modified the href to use the default language current page.

If for someone x-default like this is good like this, we can also add a prop to choose whether use defaultSiteUrl or current page.

### Wrong for me ⛔️
```
<link data-react-helmet="true" rel="alternate" hrefLang="x-default" href="http://localhost:8000/"/>
<link data-react-helmet="true" rel="alternate" hrefLang="en-US" href="http://localhost:8000/features/crm/"/>
<link data-react-helmet="true" rel="alternate" hrefLang="it-IT" href="http://localhost:8000/it/features/crm/"/>
```

### Right for me ✅ 
```
<link data-react-helmet="true" rel="alternate" hrefLang="x-default" href="http://localhost:8000/features/crm/"/>
<link data-react-helmet="true" rel="alternate" hrefLang="en-US" href="http://localhost:8000/features/crm/"/>
<link data-react-helmet="true" rel="alternate" hrefLang="it-IT" href="http://localhost:8000/it/features/crm/"/>
```