### PR TITLE
fix: skip Mdx nodes without absolute file path

### DIFF
--- a/packages/gatsby-theme-i18n/gatsby-node.js
+++ b/packages/gatsby-theme-i18n/gatsby-node.js
@@ -122,7 +122,11 @@ exports.onCreateNode = ({ node, actions }, themeOptions) => {
 
   const { defaultLang } = withDefaults(themeOptions)
 
-  if (node.internal.type === `Mdx`) {
+  if (
+    node.internal.type === `Mdx` &&
+    typeof node.fileAbsolutePath === `string` &&
+    path.extname(node.fileAbsolutePath) === `.mdx`
+  ) {
     const name = path.basename(node.fileAbsolutePath, `.mdx`)
 
     const isDefault = name === `index`


### PR DESCRIPTION
Plugins such as `gatsby-source-contentful` also create nodes with internal type `Mdx`, but do not add an absolute file path. Skipping Mdx nodes without absolute file path (from which we can derive the locale) seems ok since Contentful already handles localization.