### PR TITLE
fix(theme-i18n): localized link type prop mismatch

### DIFF
--- a/packages/gatsby-theme-i18n/index.d.ts
+++ b/packages/gatsby-theme-i18n/index.d.ts
@@ -23,6 +23,12 @@ export function LocalizedRouter({ basePath, children, ...props }: {
   children: any;
 }): JSX.Element;
 export function LocalesList(): JSX.Element;
+export function localizedPath({ defaultLang, prefixDefault, locale, path }: {
+  defaultLang: any;
+  prefixDefault: any;
+  locale: any;
+  path: any;
+}): any;
 export function useLocalization(): {
   locale: string;
   defaultLang: any;

--- a/packages/gatsby-theme-i18n/index.d.ts
+++ b/packages/gatsby-theme-i18n/index.d.ts
@@ -23,12 +23,6 @@ export function LocalizedRouter({ basePath, children, ...props }: {
   children: any;
 }): JSX.Element;
 export function LocalesList(): JSX.Element;
-export function localizedPath({ defaultLang, prefixDefault, locale, path }: {
-  defaultLang: any;
-  prefixDefault: any;
-  locale: any;
-  path: any;
-}): any;
 export function useLocalization(): {
   locale: string;
   defaultLang: any;

--- a/packages/gatsby-theme-i18n/index.d.ts
+++ b/packages/gatsby-theme-i18n/index.d.ts
@@ -15,7 +15,7 @@ export function MdxLink({ href, children, ...props }: {
 export function LocalizedLink({ to, language, ...props }: {
   [x: string]: any;
   to: any;
-  language: any;
+  language?: any;
 }): JSX.Element;
 export function LocalizedRouter({ basePath, children, ...props }: {
   [x: string]: any;


### PR DESCRIPTION
In typescript the `language` prop is required but in the js implementation it is optional.

Fixes #123