### PR TITLE
fix(example-i18n): Remove inappropriate url

### DIFF
--- a/starters/example-i18n/gatsby-config.js
+++ b/starters/example-i18n/gatsby-config.js
@@ -4,7 +4,7 @@ require(`dotenv`).config({
 
 module.exports = {
   siteMetadata: {
-    siteUrl: `https://gatsby-theme-i18n.netlify.app`,
+    siteUrl: ``,
     title: "gatsby-theme-i18n",
     description: `Default example for i18n`,
     author: `LekoArts`,


### PR DESCRIPTION
I removed the site URL deployed from another repository. Please refer to the [issue#147](https://github.com/gatsbyjs/themes/issues/147)