### PR TITLE
chore(ci): declare contents: read on cypress

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: End-to-end tests
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sets the minimum-required `GITHUB_TOKEN` scope on `cypress.yml`:

- Workflow-level `permissions:` -> `contents: read`
- No changes to jobs, steps, runners, or triggers
- YAML still parses (`yaml.safe_load` succeeds)

Rationale:

- The Cypress E2E job is read-only; nothing in it needs write access to the repo.
- Without an explicit block, the run inherits whatever default the repository's actions settings happen to be set to. That default has drifted in the past, and forks-of-forks lose track of it.
- the OpenSSF Scorecard Token-Permissions check flags missing per-workflow permissions as a finding.
- After the tj-actions/changed-files supply-chain incident from March 2025, the cost-benefit on explicit minimum scopes is firmly on the side of declaring them.
