### PR TITLE
ci: declare read-only permissions on e2e test workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,9 @@
 name: End-to-end tests
 on: [push]
+
+permissions:
+  contents: read
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the end-to-end test workflow. The workflow only checks out code and runs Cypress tests, so it does not need write access to any GitHub API scope. Restricting the token follows least-privilege best practices.